### PR TITLE
feat: Add Sliding Window Counter rate limiter implementation

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,18 +1,18 @@
-package ratelimiter
+package ratelimit
 
 import (
-	"net/http",
-	"github.com/gin-gonic/gin",
-	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
-func GinRateLimiterMiddleware(rl *Ratelimiter)  gin.HandlerFunc{
-	return func(c *gin.context) {
+func GinRateLimiterMiddleware(rl RateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
 		if !rl.Allow() {
 			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too Many Requests"})
-            c.Abort()
-            return	
+			c.Abort()
+			return
 		}
-		c.next()
+		c.Next()
 	}
 }


### PR DESCRIPTION
Implements the Sliding Window Counter algorithm which provides smooth rate limiting by using a weighted average between current and previous window counts. This eliminates the burst problem that occurs at window boundaries in Fixed Window Counter algorithms.

Key features:
- Weighted average calculation across sliding windows
- Thread-safe with mutex protection
- Implements RateLimiter interface (Allow, Wait, GetCapacity, GetAvailableTokens)
- Memory efficient (only stores two counters)
- Smooth rate limiting without boundary issues

Also includes bug fixes:
- Add missing 'fmt' import in ratelimit.go
- Fix syntax errors in middleware.go (package name, capitalization)