### PR TITLE
feat: Add Distributed Token Bucket rate limiter with Redis

### DIFF
--- a/distributed_ratelimit.go
+++ b/distributed_ratelimit.go
@@ -1,0 +1,215 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// DistributedTokenBucketRateLimiter implements a distributed token bucket algorithm using Redis
+// It allows rate limiting across multiple servers/instances by storing state in Redis.
+type DistributedTokenBucketRateLimiter struct {
+	client    *redis.Client
+	key       string
+	capacity  int
+	rate      time.Duration
+	ctx       context.Context
+}
+
+// DistributedOptions contains configuration for distributed rate limiter
+type DistributedOptions struct {
+	RedisClient *redis.Client
+	Key         string        // Redis key prefix for this rate limiter
+	Capacity    int           // Maximum tokens
+	Rate        time.Duration // Time to add one token
+}
+
+func (o DistributedOptions) validate() error {
+	if o.RedisClient == nil {
+		return fmt.Errorf("redis client cannot be nil")
+	}
+	if o.Key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+	if o.Capacity <= 0 {
+		return fmt.Errorf("capacity must be greater than 0")
+	}
+	if o.Rate <= 0 {
+		return fmt.Errorf("rate must be greater than 0")
+	}
+	return nil
+}
+
+// Lua script for atomic token bucket operations
+// This ensures thread-safety across distributed instances
+const tokenBucketScript = `
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])  -- nanoseconds per token
+local now = tonumber(ARGV[3])
+
+-- Get current state
+local tokens = redis.call('HGET', key, 'tokens')
+local last_refreshed = redis.call('HGET', key, 'last_refreshed')
+
+-- Initialize if not exists
+if not tokens then
+    tokens = capacity
+    last_refreshed = now
+else
+    tokens = tonumber(tokens)
+    last_refreshed = tonumber(last_refreshed)
+
+    -- Calculate tokens to add based on elapsed time
+    local elapsed = now - last_refreshed
+    if elapsed > 0 then
+        local tokens_to_add = math.floor(elapsed / rate)
+        if tokens_to_add > 0 then
+            tokens = math.min(capacity, tokens + tokens_to_add)
+            last_refreshed = last_refreshed + (tokens_to_add * rate)
+        end
+    end
+end
+
+-- Try to consume a token
+if tokens > 0 then
+    tokens = tokens - 1
+    redis.call('HSET', key, 'tokens', tokens)
+    redis.call('HSET', key, 'last_refreshed', last_refreshed)
+    redis.call('EXPIRE', key, math.ceil(capacity * rate / 1000000000) + 60)  -- TTL in seconds with buffer
+    return {1, tokens}  -- Success, return remaining tokens
+else
+    redis.call('HSET', key, 'tokens', tokens)
+    redis.call('HSET', key, 'last_refreshed', last_refreshed)
+    return {0, tokens}  -- Failure, no tokens available
+end
+`
+
+// Lua script for checking available tokens without consuming
+const checkTokensScript = `
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+local tokens = redis.call('HGET', key, 'tokens')
+local last_refreshed = redis.call('HGET', key, 'last_refreshed')
+
+if not tokens then
+    return capacity
+else
+    tokens = tonumber(tokens)
+    last_refreshed = tonumber(last_refreshed)
+
+    local elapsed = now - last_refreshed
+    if elapsed > 0 then
+        local tokens_to_add = math.floor(elapsed / rate)
+        tokens = math.min(capacity, tokens + tokens_to_add)
+    end
+
+    return tokens
+end
+`
+
+func NewDistributedTokenBucketRateLimiter(opts DistributedOptions) (*DistributedTokenBucketRateLimiter, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	return &DistributedTokenBucketRateLimiter{
+		client:   opts.RedisClient,
+		key:      opts.Key,
+		capacity: opts.Capacity,
+		rate:     opts.Rate,
+		ctx:      context.Background(),
+	}, nil
+}
+
+func (rl *DistributedTokenBucketRateLimiter) Allow() bool {
+	now := time.Now().UnixNano()
+
+	result, err := rl.client.Eval(rl.ctx, tokenBucketScript, []string{rl.key},
+		rl.capacity,
+		rl.rate.Nanoseconds(),
+		now).Result()
+
+	if err != nil {
+		log.Printf("Error executing rate limit script: %v", err)
+		return false
+	}
+
+	// Parse result
+	resultSlice, ok := result.([]interface{})
+	if !ok || len(resultSlice) < 2 {
+		log.Printf("Unexpected result format from Redis")
+		return false
+	}
+
+	allowed, ok := resultSlice[0].(int64)
+	if !ok {
+		log.Printf("Failed to parse allowed status")
+		return false
+	}
+
+	return allowed == 1
+}
+
+func (rl *DistributedTokenBucketRateLimiter) Wait(ctx context.Context) error {
+	for {
+		if rl.Allow() {
+			log.Printf("Wait: Request allowed after waiting")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			log.Printf("Wait: Request denied due to context timeout")
+			return ctx.Err()
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func (rl *DistributedTokenBucketRateLimiter) GetCapacity() int {
+	return rl.capacity
+}
+
+func (rl *DistributedTokenBucketRateLimiter) GetAvailableTokens() int {
+	now := time.Now().UnixNano()
+
+	result, err := rl.client.Eval(rl.ctx, checkTokensScript, []string{rl.key},
+		rl.capacity,
+		rl.rate.Nanoseconds(),
+		now).Result()
+
+	if err != nil {
+		log.Printf("Error checking available tokens: %v", err)
+		return 0
+	}
+
+	// Convert result to int
+	switch v := result.(type) {
+	case int64:
+		return int(v)
+	case string:
+		tokens, err := strconv.Atoi(v)
+		if err != nil {
+			log.Printf("Failed to parse token count: %v", err)
+			return 0
+		}
+		return tokens
+	default:
+		log.Printf("Unexpected token count type: %T", result)
+		return 0
+	}
+}
+
+// Close cleans up resources (optional, can be called when done with the limiter)
+func (rl *DistributedTokenBucketRateLimiter) Close() error {
+	return nil // Redis client should be managed by the caller
+}

--- a/examples/distributed_example.go
+++ b/examples/distributed_example.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/mikandro/rate-limiter"
+	"github.com/redis/go-redis/v9"
+)
+
+func main() {
+	// Create Redis client
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	// Test Redis connection
+	ctx := context.Background()
+	_, err := redisClient.Ping(ctx).Result()
+	if err != nil {
+		log.Fatalf("Failed to connect to Redis: %v", err)
+	}
+	fmt.Println("Connected to Redis successfully")
+
+	// Create a distributed rate limiter
+	// Allows 5 requests per second across all instances
+	limiter, err := ratelimit.NewDistributedTokenBucketRateLimiter(ratelimit.DistributedOptions{
+		RedisClient: redisClient,
+		Key:         "my-app:rate-limiter:api",
+		Capacity:    5,
+		Rate:        time.Second / 5, // One token every 200ms
+	})
+	if err != nil {
+		log.Fatalf("Failed to create rate limiter: %v", err)
+	}
+
+	fmt.Println("\nTesting Distributed Token Bucket Rate Limiter:")
+	fmt.Println("================================================")
+
+	// Simulate requests from multiple instances
+	for i := 1; i <= 10; i++ {
+		if limiter.Allow() {
+			fmt.Printf("Request %d: ✓ ALLOWED (Tokens remaining: %d)\n", i, limiter.GetAvailableTokens())
+		} else {
+			fmt.Printf("Request %d: ✗ DENIED (Tokens remaining: %d)\n", i, limiter.GetAvailableTokens())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Test Wait method
+	fmt.Println("\nTesting Wait() method with timeout:")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = limiter.Wait(ctx)
+	if err != nil {
+		fmt.Printf("Wait failed: %v\n", err)
+	} else {
+		fmt.Printf("Wait succeeded: Request allowed\n")
+	}
+
+	// Clean up
+	defer redisClient.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.21.6
 require (
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.10.0 // indirect
@@ -25,6 +27,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.16.0 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
@@ -9,6 +11,8 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -47,6 +51,8 @@ github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.16.0 h1:OotgqgLSRCmzfqChbQyG1PHC3tLNR89DG4jdOERSEP4=
+github.com/redis/go-redis/v9 v9.16.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/middleware.go
+++ b/middleware.go
@@ -1,18 +1,18 @@
-package ratelimiter
+package ratelimit
 
 import (
-	"net/http",
-	"github.com/gin-gonic/gin",
-	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
-func GinRateLimiterMiddleware(rl *Ratelimiter)  gin.HandlerFunc{
-	return func(c *gin.context) {
+func GinRateLimiterMiddleware(rl RateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
 		if !rl.Allow() {
 			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too Many Requests"})
-            c.Abort()
-            return	
+			c.Abort()
+			return
 		}
-		c.next()
+		c.Next()
 	}
 }

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -19,6 +20,7 @@ type Algorithm int
 const (
 	TokenBucket Algorithm = iota
 	LeakyBucket
+	DistributedTokenBucket
 )
 
 type Options struct {


### PR DESCRIPTION
Implements a distributed token bucket algorithm using Redis for rate limiting across multiple servers/instances. This is essential for production deployments with multiple application servers.

Key features:
- Redis-based distributed rate limiting
- Atomic operations using Lua scripts
- Thread-safe across multiple instances
- Implements RateLimiter interface
- Automatic token refill calculation
- TTL management for Redis keys

Implementation details:
- Uses Lua scripts for atomic token bucket operations
- Stores tokens and last refresh time in Redis hash
- Calculates token refill based on elapsed time
- Handles edge cases like initialization and expiration

Additional files:
- distributed_ratelimit.go: Main implementation
- examples/distributed_example.go: Usage example with Redis connection

Dependencies:
- Added github.com/redis/go-redis/v9 for Redis connectivity

Also includes bug fixes:
- Add missing 'fmt' import in ratelimit.go
- Fix syntax errors in middleware.go (package name, capitalization)